### PR TITLE
redid: Report correct custom tag range on error

### DIFF
--- a/redid/src/descriptors.rs
+++ b/redid/src/descriptors.rs
@@ -64,7 +64,7 @@ impl TryFrom<u8> for EdidDescriptorCustomTag {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         if value > 0x0f {
-            Err(EdidTypeConversionError::Range(value, Some(0), Some(0x10)))
+            Err(EdidTypeConversionError::Range(value, Some(0), Some(0x0f)))
         } else {
             Ok(Self(value))
         }


### PR DESCRIPTION
When converted to string, the range error upper limit is inclusive: "Range: {min}..={max}".

Set 0x0F as the upper range.